### PR TITLE
Added: enable/disable login message upon connecting to server

### DIFF
--- a/src/config.yml
+++ b/src/config.yml
@@ -31,3 +31,4 @@ allowedCommands:
 - rules
 - motd
 teleportBack: true
+loginMessage: true

--- a/src/de/dustplanet/passwordprotect/PasswordProtect.java
+++ b/src/de/dustplanet/passwordprotect/PasswordProtect.java
@@ -211,6 +211,7 @@ public class PasswordProtect extends JavaPlugin {
 		config.addDefault("darkness", true);
 		config.addDefault("slowness", true);
 		config.addDefault("teleportBack", true);
+		config.addDefault("loginMessage", true);		
 		config.addDefault("allowedCommands", Arrays.asList(commands));
 		commandList = config.getStringList("allowedCommands");
 		encryption = config.getString("encryption");
@@ -378,8 +379,10 @@ public class PasswordProtect extends JavaPlugin {
 	// Message
 	public void sendPasswordRequiredMessage(Player player) {
 		for (int i = 1; i < 3; i++) {
-			String messageLocalization = localization.getString("enter_password_" + i);
-			message(null, player, messageLocalization, null);
+			if (config.getBoolean("loginMessage")) {
+				String messageLocalization = localization.getString("enter_password_" + i);
+				message(null, player, messageLocalization, null);
+			}
 		}
 	}
 


### PR DESCRIPTION
Added possibility to enable or disable showing up login message upon
connection to the server. When somone is using own MOTD, then he would
probably want to disable this. To be precise – setting this to "disable"
will prevent "enter_password_" lines from "localization.yml" showing up.
