### PR TITLE
fix: Bugfix for nopassword permission, OpsRequirePassword and missing PasswordRequiredMessage

### DIFF
--- a/src/main/java/de/dustplanet/passwordprotect/PasswordProtect.java
+++ b/src/main/java/de/dustplanet/passwordprotect/PasswordProtect.java
@@ -319,6 +319,8 @@ public class PasswordProtect extends JavaPlugin {
             if (config.getBoolean("slowness", true)) {
                 player.addPotionEffect(new PotionEffect(PotionEffectType.SLOW, 20 * 86400, 5));
             }
+
+            sendPasswordRequiredMessage(player);
         }
     }
 
@@ -341,7 +343,6 @@ public class PasswordProtect extends JavaPlugin {
     private void sendToJail(Player player) {
         JailLocation jailLocation = getJailLocation(player);
         player.teleport(jailLocation);
-        sendPasswordRequiredMessage(player);
     }
 
     public void sendPasswordRequiredMessage(Player player) {


### PR DESCRIPTION
**actual state**
1. nopassword permission is only working if you are op
2. OpsRequirePassword flag does not override nopassword permission
3. PasswordRequiredMessage is not send to the player if the disableJailArea flag is set to true, because it is only send in the sendToJail(...) function.

**target state**
1. nopassword permission should work without OP
2. OpsRequirePassword flag should override nopassword permission (see your config.yml explaination at the bukkit site)
> \# Are ops forced, to enter the password, too?
> opsRequirePassword: true
3. If the Player need to login the Password required message should be sent to him.
